### PR TITLE
feat: dynamically configure slot counts for Industrial Agglomeration …

### DIFF
--- a/src/main/java/de/melanx/botanicalmachinery/blocks/containers/ContainerMenuIndustrialAgglomerationFactory.java
+++ b/src/main/java/de/melanx/botanicalmachinery/blocks/containers/ContainerMenuIndustrialAgglomerationFactory.java
@@ -1,6 +1,7 @@
 package de.melanx.botanicalmachinery.blocks.containers;
 
 import de.melanx.botanicalmachinery.blocks.tiles.BlockEntityIndustrialAgglomerationFactory;
+import de.melanx.botanicalmachinery.config.LibXServerConfig;
 import de.melanx.botanicalmachinery.helper.UnrestrictedOutputSlot;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.entity.player.Inventory;
@@ -14,13 +15,25 @@ import org.moddingx.libx.menu.BlockEntityMenu;
 public class ContainerMenuIndustrialAgglomerationFactory extends BlockEntityMenu<BlockEntityIndustrialAgglomerationFactory> {
 
     public ContainerMenuIndustrialAgglomerationFactory(MenuType<? extends BlockEntityMenu<?>> type, int windowId, Level level, BlockPos pos, Inventory playerContainer, Player player) {
-        super(type, windowId, level, pos, playerContainer, player, 3, 4);
+        super(type, windowId, level, pos, playerContainer, player, LibXServerConfig.SlotCount.industrialAgglomerationFactoryInput, LibXServerConfig.SlotCount.industrialAgglomerationFactoryInput + 1);
 
         IItemHandlerModifiable inventory = this.blockEntity.getInventory();
-        this.addSlot(new SlotItemHandler(inventory, 0, 61, 83));
-        this.addSlot(new SlotItemHandler(inventory, 1, 80, 83));
-        this.addSlot(new SlotItemHandler(inventory, 2, 99, 83));
-        this.addSlot(new UnrestrictedOutputSlot(inventory, 3, 80, 25));
+//        this.addSlot(new SlotItemHandler(inventory, 0, 61, 83));
+//        this.addSlot(new SlotItemHandler(inventory, 1, 80, 83));
+//        this.addSlot(new SlotItemHandler(inventory, 2, 99, 83));
+
+        int inputSlotCount = 9;
+        int startX = 61;
+        int startY = 83;
+        int slotSpacing = 19;
+
+        for (int i = 0; i < inputSlotCount; i++) {
+            int x = startX + (i % 3) * slotSpacing;
+            int y = startY + (i / 3) * slotSpacing;
+            this.addSlot(new SlotItemHandler(inventory, i, x, y));
+        }
+
+        this.addSlot(new UnrestrictedOutputSlot(inventory, LibXServerConfig.SlotCount.industrialAgglomerationFactoryInput, 80, 25));
         this.layoutPlayerInventorySlots(8, 113);
     }
 }

--- a/src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityIndustrialAgglomerationFactory.java
+++ b/src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityIndustrialAgglomerationFactory.java
@@ -16,6 +16,7 @@ import vazkii.botania.common.crafting.BotaniaRecipeTypes;
 import javax.annotation.Nonnull;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.IntStream;
 
 public class BlockEntityIndustrialAgglomerationFactory extends WorkingTile<TerrestrialAgglomerationRecipe> {
 
@@ -23,11 +24,26 @@ public class BlockEntityIndustrialAgglomerationFactory extends WorkingTile<Terre
 
     private final BaseItemStackHandler inventory;
 
+    private final int[] itemOutputSlots;
+
     public BlockEntityIndustrialAgglomerationFactory(BlockEntityType<?> type, BlockPos pos, BlockState state) {
-        super(type, BotaniaRecipeTypes.TERRA_PLATE_TYPE, pos, state, LibXServerConfig.MaxManaCapacity.industrialAgglomerationFactory, 0, 3);
-        this.inventory = BaseItemStackHandler.builder(4)
-                .validator(stack -> this.level != null && RecipeHelper.isItemValidInput(this.level.getRecipeManager(), BotaniaRecipeTypes.TERRA_PLATE_TYPE, stack), 0, 1, 2)
-                .output(3)
+        super(type, BotaniaRecipeTypes.TERRA_PLATE_TYPE, pos, state, LibXServerConfig.MaxManaCapacity.industrialAgglomerationFactory, 0, LibXServerConfig.SlotCount.industrialAgglomerationFactoryInput);
+
+        int itemInputSlotSize = LibXServerConfig.SlotCount.industrialAgglomerationFactoryInput;
+        int itemOutputSlotSize = LibXServerConfig.SlotCount.industrialAgglomerationFactoryOutput;
+        int itemSlotSize = itemInputSlotSize + itemOutputSlotSize;
+        int[] itemInputSlots = new int[itemInputSlotSize];
+        for (int i = 0; i < itemInputSlotSize; i++) {
+            itemInputSlots[i] = i;
+        }
+        itemOutputSlots = new int[itemOutputSlotSize];
+        for (int i = 0; i < itemOutputSlotSize; i++) {
+            itemOutputSlots[i] = i + itemInputSlotSize;
+        }
+
+        this.inventory = BaseItemStackHandler.builder(itemSlotSize)
+                .validator(stack -> this.level != null && RecipeHelper.isItemValidInput(this.level.getRecipeManager(), BotaniaRecipeTypes.TERRA_PLATE_TYPE, stack), itemInputSlots)
+                .output(itemOutputSlots)
                 .contentsChanged(() -> {
                     this.setChanged();
                     this.setDispatchable();
@@ -62,7 +78,7 @@ public class BlockEntityIndustrialAgglomerationFactory extends WorkingTile<Terre
 
     @Override
     protected Predicate<Integer> getExtracts(Supplier<IItemHandlerModifiable> inventory) {
-        return slot -> slot == 3;
+        return slot -> IntStream.of(itemOutputSlots).anyMatch(outputSlot -> outputSlot == slot);
     }
 
     @Nonnull

--- a/src/main/java/de/melanx/botanicalmachinery/config/LibXServerConfig.java
+++ b/src/main/java/de/melanx/botanicalmachinery/config/LibXServerConfig.java
@@ -75,4 +75,16 @@ public class LibXServerConfig {
         @IntRange(min = 1, max = 100)
         public static int mechanicalRunicAltar = 1;
     }
+
+    @Group("The default number of slots in machine, only supported for Industrial Agglomeration Factory.")
+    public static class SlotCount {
+
+        @Config("The number of input slots in Industrial Agglomeration Factory.")
+        @IntRange(min = 1, max = 64)
+        public static int industrialAgglomerationFactoryInput = 3;
+
+        @Config("The number of output slots in Industrial Agglomeration Factory.")
+        @IntRange(min = 1, max = 9)
+        public static int industrialAgglomerationFactoryOutput = 1;
+    }
 }


### PR DESCRIPTION
Hi, there, excellent work!
I've been playing some modpacks and find out some custom recipes of Terrestrial Agglomeration Plate require more than three types of input items, while Industrial Agglomeration Factory only has 3 input slots, which is a bit of inconvenient, so I made some modifications to the code to enable changes to the number of input slots. Following is the detailed PR content. Additionally, since I am not very familiar with GUI rendering and drawing operations, **I did not make corresponding modifications to the GUI**. Considering that multi-slot usage scenarios are mostly related to automation integrated with AE, modifying the GUI might not be particularly important.

This pull request includes several changes to the `ContainerMenuIndustrialAgglomerationFactory` and `BlockEntityIndustrialAgglomerationFactory` classes, mainly focusing on making the slot count configurable via `LibXServerConfig`. The changes also involve updating the slot handling logic to accommodate the new configurable slot counts.

### Configuration Updates:
* [`src/main/java/de/melanx/botanicalmachinery/config/LibXServerConfig.java`](diffhunk://#diff-1bf838ad05c5cd5e676d4cde89e203d82c2d83ff2eaa768d18cceb7ccab84925R78-R89): Added new configuration options for the number of input and output slots in the Industrial Agglomeration Factory.

### Slot Handling Updates:
* [`src/main/java/de/melanx/botanicalmachinery/blocks/containers/ContainerMenuIndustrialAgglomerationFactory.java`](diffhunk://#diff-9cf6ef8a33e768c9553de8a8409a7238247094e5513fcbe71953a625dc0b6870L17-R36): Modified the constructor to use the configurable slot counts and updated the slot addition logic to dynamically create input slots based on the configuration.
* [`src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityIndustrialAgglomerationFactory.java`](diffhunk://#diff-3ad5624450b2d90dc9c7776adde91d6a6d87d33c42c2b95840890ee78b10266bR19-R46): Updated the constructor to initialize the inventory with configurable slot counts and added logic to handle input and output slots dynamically.
* [`src/main/java/de/melanx/botanicalmachinery/blocks/tiles/BlockEntityIndustrialAgglomerationFactory.java`](diffhunk://#diff-3ad5624450b2d90dc9c7776adde91d6a6d87d33c42c2b95840890ee78b10266bL65-R81): Updated the `getExtracts` method to use the new output slot configuration.

### Import Statements:
* [`src/main/java/de/melanx/botanicalmachinery/blocks/containers/ContainerMenuIndustrialAgglomerationFactory.java`](diffhunk://#diff-9cf6ef8a33e768c9553de8a8409a7238247094e5513fcbe71953a625dc0b6870R4): Added import for `LibXServerConfig`.